### PR TITLE
Ignore R1720: Unnecessary "elif" after "raise" (no-else-raise)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -84,7 +84,8 @@ disable=
     unused-argument,
     locally-disabled,
     no-self-use,
-    too-many-lines
+    too-many-lines,
+    no-else-raise
 
 [REPORTS]
 


### PR DESCRIPTION
Signed-off-by: Richard Berg <rberg@bitwise.io>