### PR TITLE
Add more specific exclude paths for bandit

### DIFF
--- a/bin/run_bandit
+++ b/bin/run_bandit
@@ -30,6 +30,7 @@ directories="
     simulator/build
     simulator/tests
     tests
+    tests/sawtooth_poet_tests/*
 "
 
 if [ ! -d "$top_dir/build" ]; then


### PR DESCRIPTION
Workaround for bug reported here: https://github.com/PyCQA/bandit/issues/488

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>