### PR TITLE
Add additional protocol for 1.0 compatibility

### DIFF
--- a/engine/sawtooth_poet_engine/engine.py
+++ b/engine/sawtooth_poet_engine/engine.py
@@ -51,6 +51,9 @@ class PoetEngine(Engine):
     def version(self):
         return '0.1'
 
+    def additional_protocols(self):
+        return [('poet', '0.1')]
+
     def stop(self):
         self._exit = True
 


### PR DESCRIPTION
Depends on https://github.com/hyperledger/sawtooth-sdk-python/pull/8

Adds the `poet`/`0.1` consensus engine protocol for backwards
compatibility with Sawtooth 1.0 networks.

Signed-off-by: Logan Seeley <seeley@bitwise.io>