### PR TITLE
Fix wait certificate checking and creation

### DIFF
--- a/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -168,6 +168,7 @@ class PoetBlockVerifier(BlockVerifierInterface):
             wait_certificate.check_valid(
                 poet_enclave_module=poet_enclave_module,
                 previous_certificate_id=previous_certificate_id,
+                validator_id=validator_info.id,
                 poet_public_key=validator_info.signup_info.poet_public_key,
                 consensus_state=consensus_state,
                 poet_settings_view=poet_settings_view)

--- a/core/sawtooth_poet/poet_consensus/wait_certificate.py
+++ b/core/sawtooth_poet/poet_consensus/wait_certificate.py
@@ -174,6 +174,7 @@ class WaitCertificate:
     def check_valid(self,
                     poet_enclave_module,
                     previous_certificate_id,
+                    validator_id,
                     poet_public_key,
                     consensus_state,
                     poet_settings_view):
@@ -184,6 +185,8 @@ class WaitCertificate:
                 underlying PoET enclave.
             previous_certificate_id (str): The ID of the wait certificate for
                 the block attempting to build upon
+            validator_id (str): The ID (sometimes called the address) of the
+                validator that published this block.
             poet_public_key (str): The PoET public key that corresponds to
                 the private key used to sign the certificate.  This is
                 obtained from the signup information for the validator
@@ -218,6 +221,15 @@ class WaitCertificate:
                     '{1}'.format(
                         enclave_certificate.previous_certificate_id,
                         previous_certificate_id))
+
+        if enclave_certificate.validator_address != \
+                validator_id:
+            raise \
+                ValueError(
+                    'Publishing validator ID does not match: {0} != '
+                    '{1}'.format(
+                        enclave_certificate.validator_address,
+                        validator_id))
 
         try:
             poet_enclave_module.verify_wait_certificate(

--- a/core/tests/test_consensus/test_wait_certificate.py
+++ b/core/tests/test_consensus/test_wait_certificate.py
@@ -293,7 +293,7 @@ class TestWaitCertificate(TestCase):
         # create mock_poet_enclave_wait_timer
         mock_poet_enclave_wait_timer = \
             mock.Mock(sealed_signup_data=signup_info.sealed_signup_data,
-                      validator_address='1060 W Addison Street',
+                      validator_address='1660 Pennsylvania Avenue NW',
                       duration=1.0,
                       previous_certificate_id=NULL_BLOCK_IDENTIFIER,
                       local_mean=5.0,
@@ -308,7 +308,7 @@ class TestWaitCertificate(TestCase):
                       previous_certificate_id=NULL_BLOCK_IDENTIFIER,
                       local_mean=5.0,
                       request_time=time.time(),
-                      validator_address='1060 W Addison Street',
+                      validator_address='1660 Pennsylvania Avenue NW',
                       nonce=NULL_BLOCK_IDENTIFIER,
                       block_hash="Reader's Digest",
                       signature='00112233445566778899aabbccddeeff',
@@ -425,7 +425,7 @@ class TestWaitCertificate(TestCase):
 
         # create mock_poet_enclave_wait_timer
         mock_poet_enclave_wait_timer = \
-            mock.Mock(validator_address='1060 W Addison Street',
+            mock.Mock(validator_address='1660 Pennsylvania Avenue NW',
                       duration=1.0,
                       previous_certificate_id=NULL_BLOCK_IDENTIFIER,
                       local_mean=5.0,
@@ -439,7 +439,7 @@ class TestWaitCertificate(TestCase):
                       previous_certificate_id=NULL_BLOCK_IDENTIFIER,
                       local_mean=5.0,
                       request_time=time.time(),
-                      validator_address='1060 W Addison Street',
+                      validator_address='1660 Pennsylvania Avenue NW',
                       nonce=NULL_BLOCK_IDENTIFIER,
                       block_hash="Reader's Digest",
                       signature='00112233445566778899aabbccddeeff',

--- a/core/tests/test_consensus/test_wait_certificate.py
+++ b/core/tests/test_consensus/test_wait_certificate.py
@@ -375,9 +375,31 @@ class TestWaitCertificate(TestCase):
         wc.check_valid(
             poet_enclave_module=mock_poet_enclave_module,
             previous_certificate_id=NULL_BLOCK_IDENTIFIER,
+            validator_id='1660 Pennsylvania Avenue NW',
             poet_public_key=signup_info.poet_public_key,
             consensus_state=self.mock_consensus_state,
             poet_settings_view=self.mock_poet_settings_view)
+
+        # Verify that check_valid enforces agreement on fields
+        # Set mismatched previous_certificate_id
+        with self.assertRaises(ValueError):
+            wc.check_valid(
+                poet_enclave_module=mock_poet_enclave_module,
+                previous_certificate_id='0123456789ABCDEF',
+                validator_id='1660 Pennsylvania Avenue NW',
+                poet_public_key=signup_info.poet_public_key,
+                consensus_state=self.mock_consensus_state,
+                poet_settings_view=self.mock_poet_settings_view)
+
+        # Set mismatched validator_id
+        with self.assertRaises(ValueError):
+            wc.check_valid(
+                poet_enclave_module=mock_poet_enclave_module,
+                previous_certificate_id=NULL_BLOCK_IDENTIFIER,
+                validator_id='1661 Pennsylvania Avenue NW',
+                poet_public_key=signup_info.poet_public_key,
+                consensus_state=self.mock_consensus_state,
+                poet_settings_view=self.mock_poet_settings_view)
 
         validator_info = \
             ValidatorInfo(
@@ -411,6 +433,7 @@ class TestWaitCertificate(TestCase):
         another_wc.check_valid(
             poet_enclave_module=mock_poet_enclave_module,
             previous_certificate_id=wc.identifier,
+            validator_id='1660 Pennsylvania Avenue NW',
             poet_public_key=signup_info.poet_public_key,
             consensus_state=self.mock_consensus_state,
             poet_settings_view=self.mock_poet_settings_view)
@@ -516,6 +539,7 @@ class TestWaitCertificate(TestCase):
         wc_copy.check_valid(
             poet_enclave_module=mock_poet_enclave_module,
             previous_certificate_id=NULL_BLOCK_IDENTIFIER,
+            validator_id='1660 Pennsylvania Avenue NW',
             poet_public_key=signup_info.poet_public_key,
             consensus_state=self.mock_consensus_state,
             poet_settings_view=self.mock_poet_settings_view)


### PR DESCRIPTION
Repair two defects in wait certificate checking and creation. 
1. Validator must check all fields of the wait certificate. 
    (was not checking agreement of validator ID)
2. Enclave must create a wait certificate with an uninfluenced ID.
    (nonce generation was manipulatable)