### PR TITLE
fixed TypeError issue while creating wait-certificate

### DIFF
--- a/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -603,12 +603,13 @@ class PoetBlockPublisher(BlockPublisherInterface):
             poet_key_state = self._poet_key_state_store[active_key]
             sealed_signup_data = poet_key_state.sealed_signup_data
             try:
+                block_header_hex = block_header.hex()
                 wait_certificate = \
                     WaitCertificate.create_wait_certificate(
                         poet_enclave_module=poet_enclave_module,
                         sealed_signup_data=sealed_signup_data,
                         wait_timer=self._wait_timer,
-                        block_hash=block_header)
+                        block_hash=block_header_hex)
                 consensus = json.dumps(wait_certificate.dump()).encode()
             except ValueError as ve:
                 LOGGER.error('Failed to create wait certificate: %s', ve)


### PR DESCRIPTION
The "create_wait_certificate" method in swig file(poet_enclave_module.i) expects block_hash argument of type 'string' whereas the python sends the argument of type 'bytes'. Consequently, the swig file throws "Type Error".To address this, the python code wraps the block_hash(bytes) into block_hash_hex(string) in poet_block_publisher.py and sends it to the swig.


Signed-off-by: raneja14 <raneja7@gmail.com>