### PR TITLE
Propose new maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @cianx @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @vaporos
+*       @agunde406 @chenette @cianx @dcmiddle @dplumb94 @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,9 @@
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | James Mitchell | jsmitchell | jsmitchell |
+| Logan Seeley | ltseeley | ltseeley |
 | Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
 


### PR DESCRIPTION
Propose that Logan Seeley and Richard Berg be added as maintainers.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.