### PR TITLE
Only publish when no blocks are validating 

### DIFF
--- a/engine/sawtooth_poet_engine/engine.py
+++ b/engine/sawtooth_poet_engine/engine.py
@@ -224,6 +224,7 @@ class PoetEngine(Engine):
     def _handle_valid_block(self, block_id):
         self._validating_blocks.discard(block_id)
         block = self._get_block(block_id)
+        LOGGER.info('Validated %s', block)
 
         if self._check_consensus(block):
             LOGGER.info('Passed consensus check: %s', block.block_id.hex())
@@ -236,6 +237,7 @@ class PoetEngine(Engine):
     def _handle_invalid_block(self, block_id):
         self._validating_blocks.discard(block_id)
         block = self._get_block(block_id)
+        LOGGER.info('Block invalid: %s', block)
         self._fail_block(block.block_id)
 
     def _handle_peer_msgs(self, msg):

--- a/engine/sawtooth_poet_engine/engine.py
+++ b/engine/sawtooth_poet_engine/engine.py
@@ -217,19 +217,18 @@ class PoetEngine(Engine):
         block = PoetBlock(block)
         LOGGER.info('Received %s', block)
 
-        if self._check_consensus(block):
-            LOGGER.info('Passed consensus check: %s', block.block_id.hex())
-            self._check_block(block.block_id)
-        else:
-            LOGGER.info('Failed consensus check: %s', block.block_id.hex())
-            self._fail_block(block.block_id)
+        self._check_block(block.block_id)
 
     def _handle_valid_block(self, block_id):
         block = self._get_block(block_id)
 
-        self._pending_forks_to_resolve.push(block)
-
-        self._process_pending_forks()
+        if self._check_consensus(block):
+            LOGGER.info('Passed consensus check: %s', block.block_id.hex())
+            self._pending_forks_to_resolve.push(block)
+            self._process_pending_forks()
+        else:
+            LOGGER.info('Failed consensus check: %s', block.block_id.hex())
+            self._fail_block(block.block_id)
 
     def _handle_invalid_block(self, block_id):
         block = self._get_block(block_id)

--- a/engine/sawtooth_poet_engine/engine.py
+++ b/engine/sawtooth_poet_engine/engine.py
@@ -161,6 +161,7 @@ class PoetEngine(Engine):
         handlers = {
             Message.CONSENSUS_NOTIFY_BLOCK_NEW: self._handle_new_block,
             Message.CONSENSUS_NOTIFY_BLOCK_VALID: self._handle_valid_block,
+            Message.CONSENSUS_NOTIFY_BLOCK_INVALID: self._handle_invalid_block,
             Message.CONSENSUS_NOTIFY_BLOCK_COMMIT:
                 self._handle_committed_block,
             Message.CONSENSUS_NOTIFY_PEER_CONNECTED: self._handle_peer_msgs,
@@ -229,6 +230,10 @@ class PoetEngine(Engine):
         self._pending_forks_to_resolve.push(block)
 
         self._process_pending_forks()
+
+    def _handle_invalid_block(self, block_id):
+        block = self._get_block(block_id)
+        self._fail_block(block.block_id)
 
     def _handle_peer_msgs(self, msg):
         # PoET does not care about peer notifications


### PR DESCRIPTION
Updates PoET to only attempt to publish a new block when there are no
blocks currently validating. This prevents the node from attempting to
publish competing blocks while it is catching up.

Signed-off-by: Logan Seeley <seeley@bitwise.io>