### PR TITLE
Disable pylint invalid-overridden-method in poet engine

### DIFF
--- a/engine/sawtooth_poet_engine/engine.py
+++ b/engine/sawtooth_poet_engine/engine.py
@@ -46,9 +46,13 @@ class PoetEngine(Engine):
         self._validating_blocks = set()
         self._pending_forks_to_resolve = PendingForks()
 
+    # Ignore invalid override pylint issues
+    # pylint: disable=invalid-overridden-method
     def name(self):
         return 'PoET'
 
+    # Ignore invalid override pylint issues
+    # pylint: disable=invalid-overridden-method
     def version(self):
         return '0.1'
 


### PR DESCRIPTION
Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>