### PR TITLE
Pin sawtooth-poet tests to 1.3 nightly validator

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -17,19 +17,20 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+# Get nightly sawtooth-core 1.3 images to be used in the tests
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/droptarget/nightly bionic universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \
     curl \
-    python3-sawtooth-block-info \
     python3-sawtooth-cli \
     python3-sawtooth-intkey \
     python3-sawtooth-rest-api \
-    python3-sawtooth-settings \
     python3-sawtooth-validator \
+    sawtooth-settings-tp \
+    sawtooth-block-info-tp\
     sawtooth-intkey-tp-go \
     sawtooth-intkey-workload \
     sawtooth-smallbank-tp-go \


### PR DESCRIPTION
sawtooth-core is working towards 2.0 which includes
replacing the python version of the transaction execution
platform with Transact. Currently, this requires that
all transaction processors/smart contracts be compiled into
the validator and are written in Rust, as transact does not
currently support the required adapters to deal with external
transaction processors.

Since PoET requires a transaction processor that is currently only
written in Python, PoET is not compatible with the new version of
the validator. The nightly validator tests now points to the
nightly 1.3 images, which are the current main branch for future
validator 1.x work.

Do to the change in versions, the python version of sawtooth setting and
block info have been updated to the rust versions.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>