### PR TITLE
Pin pylint to fix CI builds

### DIFF
--- a/ci/lint
+++ b/ci/lint
@@ -51,7 +51,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
     python3-zmq \
     unzip \
     && pip3 install \
-    pylint \
+    pylint==2.6.2 \
     pycodestyle \
     bandit \
     coverage --upgrade


### PR DESCRIPTION
Since the release of version 2.7.0 pylint has been segfaulting during the
linting step of CI builds. This can be researched more comprehensively once
active development continues on Sawtooth.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>