### PR TITLE
Pin Coverage to version 5.5 in bumper tests

### DIFF
--- a/tests/Dockerfile-bumper
+++ b/tests/Dockerfile-bumper
@@ -45,7 +45,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial 
     sawtooth-smallbank-workload \
     software-properties-common
 
-RUN pip3 install coverage --upgrade
+RUN pip3 install coverage==5.5 --upgrade
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
  && add-apt-repository \


### PR DESCRIPTION
The 6.0 release of Coverage dropped support for python 3.5, which is the last
supported version on Xenial, which is the distribution bumper was based on.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>