### PR TITLE
Pin mistune version to fix doc build error

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -75,6 +75,7 @@ RUN apt-get update && apt-get install -y -q \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install \
     docutils==0.16 \
+    mistune==0.8.4 \
     sphinx \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \


### PR DESCRIPTION
Sphinx-openapi depends on m2r which pulls in mistune without specifying a
version. Mistune has recently updated to 2.0.0 which includes some API
changes which were not backwards compatible.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>