### PR TITLE
Pin bandit version

### DIFF
--- a/ci/bandit
+++ b/ci/bandit
@@ -25,7 +25,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
     python3-dev \
     python3-pip \
  && pip3 install \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-poet/bin

--- a/ci/lint
+++ b/ci/lint
@@ -53,7 +53,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
     && pip3 install \
     pylint==2.6.2 \
     pycodestyle \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-poet/bin

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -56,7 +56,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
     pylint \
-    bandit
+    bandit==1.7.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
The 1.7.2 release of Bandit drops support for python 3.6, which is the latest
available for ubuntu bionic.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>